### PR TITLE
Update lxde-applications.menu

### DIFF
--- a/layout/lxde-applications.menu
+++ b/layout/lxde-applications.menu
@@ -149,17 +149,55 @@
 		</Menu> <!-- End Other -->
 
 	<Menu>
-		<Name>DesktopSettings</Name>
-		<Directory>lxde-settings.directory</Directory>
-		<OnlyUnallocated/>
+		<Name>Settings</Name>
+		<Directory>lxde-menu-system.directory</Directory>
+		<Menu>
+			<Name>Preferences</Name>
+			<Directory>lxde-settings.directory</Directory>
+			<Include>
+				<And>
+					<Category>Settings</Category>
+					<Not>
+						<Or>
+							<Category>System</Category>
+							<Filename>gnomecc.desktop</Filename>
+							<Filename>lxcc.desktop</Filename>
+						</Or>
+					</Not>
+				</And>
+			</Include>
+		</Menu>
+
+		<!-- System Settings -->
+		<Menu>
+			<Name>Administration</Name>
+			<Directory>lxde-settings-system.directory</Directory>
+			<Include>
+				<And>
+					<Or>
+						<Category>PackageManager</Category>
+						<Category>SystemSetup</Category>
+						<And>
+							<Category>Settings</Category>
+							<Category>System</Category>
+						</And>
+					</Or>
+					<Not>
+						<Or>
+							<Filename>lxcc.desktop</Filename>
+						</Or>
+					</Not>
+				</And>
+			</Include>
+		</Menu>		 <!-- End System Settings -->
+
 		<Include>
-			<Or>
-				<Category>Settings</Category>
-				<Category>PackageManager</Category>
-				<Category>System</Category>
-			</Or>
+			<Filename>lxcc.desktop</Filename>
 		</Include>
+
 		<Layout>
+			<Menuname>Preferences</Menuname>
+			<Menuname>Administration</Menuname>
 			<Merge type="menus"/>
 			<Merge type="files"/>
 		</Layout>


### PR DESCRIPTION
The original `DesktopSettings` section was a bit of a mess. Untouched for 6 years? New layout is similar to what is seen in openSUSE.

What do you think of this? I'm unsure of what the lxde team expect. The number one reason for updating this is to create a sane default. The original behaviour of basically lumping almost all "leftover" desktop files under one category can create a rather large mess depending on the distro used. The openSUSE version is nice enough, but I'm also wondering if perhaps `Administration` and `Preferences` could be under their own "root" menu? Or would this create too many categories in the root?
