### PR TITLE
fix en_CA translation

### DIFF
--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -16,9 +16,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Pootle 2.8\n"
-"X-POOTLE-MTIME: 1538404681.852341\n"
 
 #: ../desktop-directories/lxde-audio-video.directory.in.h:1
 #, fuzzy
@@ -56,7 +53,7 @@ msgstr "Games"
 
 #: ../desktop-directories/lxde-game.directory.in.h:2
 msgid "Games and amusements"
-msgstr "Games and amusements"
+msgstr "Games and Amusements"
 
 #: ../desktop-directories/lxde-graphics.directory.in.h:1
 msgid "Graphics"
@@ -68,27 +65,27 @@ msgstr "Graphics applications"
 
 #: ../desktop-directories/lxde-hardware.directory.in.h:1
 msgid "Hardware"
-msgstr "Maquinari"
+msgstr "Hardware"
 
 #: ../desktop-directories/lxde-hardware.directory.in.h:2
 msgid "Settings for several hardware devices"
-msgstr "Configuració de diversos dispositius de maquinari"
+msgstr "Settings for several hardware devices"
 
 #: ../desktop-directories/lxde-internet-and-network.directory.in.h:1
 msgid "Internet and Network"
-msgstr "Internet i xarxa"
+msgstr "Internet and Network"
 
 #: ../desktop-directories/lxde-internet-and-network.directory.in.h:2
 msgid "Network-related settings"
-msgstr "Configuració de la xarxa"
+msgstr "Network-related settings"
 
 #: ../desktop-directories/lxde-look-and-feel.directory.in.h:1
 msgid "Look and Feel"
-msgstr "Aspecte i comportament"
+msgstr "Look and Feel"
 
 #: ../desktop-directories/lxde-look-and-feel.directory.in.h:2
 msgid "Settings controlling the desktop appearance and behavior"
-msgstr "Paràmetres que controlen l'aspecte i el comportament de l'escriptori"
+msgstr "Settings controlling the desktop appearance and behaviour"
 
 #: ../desktop-directories/lxde-menu-applications.directory.in.h:1
 msgid "Applications"
@@ -103,11 +100,11 @@ msgstr "Applications"
 #: ../desktop-directories/lxde-menu-system.directory.in.h:1
 #: ../desktop-directories/lxde-system.directory.in.h:1
 msgid "System"
-msgstr "Eines del sistema"
+msgstr "System"
 
 #: ../desktop-directories/lxde-menu-system.directory.in.h:2
 msgid "Personal preferences and administration settings"
-msgstr "Preferències personals i configuració d'administració"
+msgstr "Personal preferences and administration settings"
 
 #: ../desktop-directories/lxde-network.directory.in.h:1
 msgid "Internet"
@@ -117,7 +114,7 @@ msgstr "Internet"
 #, fuzzy
 #| msgid "Programs for Internet access such as web and email"
 msgid "Programs for Internet access"
-msgstr "Programs for Internet access, such as web and email"
+msgstr "Programs for Internet access such as web and e-mail"
 
 #: ../desktop-directories/lxde-office.directory.in.h:1
 msgid "Office"
@@ -145,11 +142,11 @@ msgstr "Personal"
 
 #: ../desktop-directories/lxde-personal.directory.in.h:2
 msgid "Personal settings"
-msgstr "Configuració personal"
+msgstr "Personal settings"
 
 #: ../desktop-directories/lxde-science-math.directory.in.h:1
 msgid "Science & Math"
-msgstr ""
+msgstr "Science & Maths"
 
 #: ../desktop-directories/lxde-science-math.directory.in.h:2
 msgid "Scientific and mathematical software"
@@ -157,7 +154,7 @@ msgstr ""
 
 #: ../desktop-directories/lxde-science.directory.in.h:1
 msgid "Science"
-msgstr ""
+msgstr "Science & Maths"
 
 #: ../desktop-directories/lxde-science.directory.in.h:2
 msgid "Scientific software"
@@ -181,7 +178,7 @@ msgstr "Administration"
 #, fuzzy
 #| msgid "Change system-wide settings (affects all users)"
 msgid "System-wide settings (affecting all users)"
-msgstr "Canvia la configuració de tot el sistema (afecta tots els usuaris)"
+msgstr "Change system-wide settings (affects all users)"
 
 #: ../desktop-directories/lxde-system.directory.in.h:2
 #, fuzzy
@@ -191,11 +188,11 @@ msgstr "System configuration and monitoring"
 
 #: ../desktop-directories/lxde-utility-accessibility.directory.in.h:1
 msgid "Universal Access"
-msgstr "Accés universal"
+msgstr "Universal Access"
 
 #: ../desktop-directories/lxde-utility-accessibility.directory.in.h:2
 msgid "Universal Access Settings"
-msgstr "Configuració de l'accés universal"
+msgstr "Universal Access Settings"
 
 #: ../desktop-directories/lxde-utility.directory.in.h:1
 msgid "Accessories"
@@ -212,19 +209,16 @@ msgstr "Desktop accessories"
 #~ msgstr "Programming"
 
 #~ msgid "System settings"
-#~ msgstr "Configuració del sistema"
+#~ msgstr "System settings"
 
 #~ msgid "System Tools"
 #~ msgstr "System Tools"
 
-#~ msgid "Accessibility"
-#~ msgstr "Accessibility"
+#~ msgid "Universal access related preferences"
+#~ msgstr "Universal access related preferences"
 
-#~ msgid "Desktop"
-#~ msgstr "Desktop"
-
-#~ msgid "Accessibility related preferences"
-#~ msgstr "Accessibility-related preferences"
+#~ msgid "Personal preferences and settings"
+#~ msgstr "Personal preferences and settings"
 
 #~ msgid "Menu Editor"
 #~ msgstr "Menu Editor"
@@ -289,7 +283,7 @@ msgstr "Desktop accessories"
 #~ "\n"
 #~ "\n"
 #~ "\n"
-#~ "==== Menu changed; reloading ====\n"
+#~ "==== Menu changed, reloading ====\n"
 #~ "\n"
 #~ "\n"
 
@@ -298,3 +292,15 @@ msgstr "Desktop accessories"
 
 #~ msgid "- test GNOME's implementation of the Desktop Menu Specification"
 #~ msgstr "- test GNOME's implementation of the Desktop Menu Specification"
+
+#~ msgid "Accessibility"
+#~ msgstr "Accessibility"
+
+#~ msgid "Accessibility Settings"
+#~ msgstr "Accessibility Settings"
+
+#~ msgid "Desktop"
+#~ msgstr "Desktop"
+
+#~ msgid "Hide"
+#~ msgstr "Hide"


### PR DESCRIPTION
for some reason, many strings were in spanish (?). Those incorrect strings were simply copied over from en_GB.

Fixes #11 